### PR TITLE
Fix issue #5

### DIFF
--- a/plugin/bbye.vim
+++ b/plugin/bbye.vim
@@ -35,7 +35,7 @@ function! s:bdelete(bang, buffer_name)
 		" If found a new buffer for this window, mission accomplished:
 		if bufnr("%") != buffer | continue | endif
 
-		call s:new(a:bang) 
+		call s:new(a:bang)
 	endfor
 
 	" Because tabbars and other appearing/disappearing windows change
@@ -46,7 +46,7 @@ function! s:bdelete(bang, buffer_name)
 	" If it hasn't been already deleted by &bufhidden, end its pains now.
 	" Unless it previously was an unnamed buffer and :enew returned it again.
 	if bufexists(buffer) && buffer != bufnr("%")
-		exe "bdelete" . a:bang . " " . buffer
+		exe "bwipeout" . a:bang . " " . buffer
 	endif
 endfunction
 
@@ -81,4 +81,4 @@ function! s:warn(msg)
 endfunction
 
 command! -bang -complete=buffer -nargs=? Bdelete
-	\ :call s:bdelete(<q-bang>, <q-args>)
+			\ :call s:bdelete(<q-bang>, <q-args>)

--- a/plugin/bbye.vim
+++ b/plugin/bbye.vim
@@ -45,8 +45,8 @@ function! s:bdelete(bang, buffer_name)
 
 	" If it hasn't been already deleted by &bufhidden, end its pains now.
 	" Unless it previously was an unnamed buffer and :enew returned it again.
-	if bufexists(buffer) && buffer != bufnr("%")
-		exe "bwipeout" . a:bang . " " . buffer
+	if buflisted(buffer) && buffer != bufnr("%")
+		exe "bdelete" . a:bang . " " . buffer
 	endif
 endfunction
 


### PR DESCRIPTION
Unlisted buffers can be found by 'bufexists' function. However, 'bdelete' command cannot delete the unlisted buffer. That is why the error occurs.