### PR TITLE
Add :Bwipeout command

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Bbye gives you a `:Bdelete` command that behaves like a well designed citizen:
 
 Regain your throne as king of buffers!
 
+Bbye also gives you a `:Bwipeout` command that has the same behavior as `:Bdelete` but uses `:bwipeout` to actually destroy the buffer.
 
 Installing
 ----------

--- a/plugin/bbye.vim
+++ b/plugin/bbye.vim
@@ -1,7 +1,7 @@
 if exists("g:loaded_bbye") || &cp | finish | endif
 let g:loaded_bbye = 1
 
-function! s:bdelete(bang, buffer_name, action)
+function! s:bdelete(action, bang, buffer_name)
 	let buffer = s:str2bufnr(a:buffer_name)
 	let w:bbye_back = 1
 
@@ -81,7 +81,7 @@ function! s:warn(msg)
 endfunction
 
 command! -bang -complete=buffer -nargs=? Bdelete
-	\ :call s:bdelete(<q-bang>, <q-args>, 'bdelete')
+	\ :call s:bdelete("bdelete", <q-bang>, <q-args>)
 
 command! -bang -complete=buffer -nargs=? Bwipeout
-	\ :call s:bdelete(<q-bang>, <q-args>, 'bwipeout')
+	\ :call s:bdelete("bwipeout", <q-bang>, <q-args>)

--- a/plugin/bbye.vim
+++ b/plugin/bbye.vim
@@ -50,6 +50,55 @@ function! s:bdelete(bang, buffer_name)
 	endif
 endfunction
 
+function! s:bwipeout(bang, buffer_name)
+	let buffer = s:str2bufnr(a:buffer_name)
+	let w:bbye_back = 1
+
+	if buffer < 0
+		return s:warn("E516: No buffers were deleted. No match for ".a:buffer_name)
+	endif
+
+	if getbufvar(buffer, "&modified") && empty(a:bang)
+		let error = "E89: No write since last change for buffer "
+		return s:warn(error . buffer . " (add ! to override)")
+	endif
+
+	" If the buffer is set to delete and it contains changes, we can't switch
+	" away from it. Hide it before eventual deleting:
+	if getbufvar(buffer, "&modified") && !empty(a:bang)
+		call setbufvar(buffer, "&bufhidden", "hide")
+	endif
+
+	" For cases where adding buffers causes new windows to appear or hiding some
+	" causes windows to disappear and thereby decrement, loop backwards.
+	for window in reverse(range(1, winnr("$")))
+		" For invalid window numbers, winbufnr returns -1.
+		if winbufnr(window) != buffer | continue | endif
+		execute window . "wincmd w"
+
+		" Bprevious also wraps around the buffer list, if necessary:
+		try | exe bufnr("#") > 0 && buflisted(bufnr("#")) ? "buffer #" : "bprevious"
+		catch /^Vim([^)]*):E85:/ " E85: There is no listed buffer
+		endtry
+
+		" If found a new buffer for this window, mission accomplished:
+		if bufnr("%") != buffer | continue | endif
+
+		call s:new(a:bang) 
+	endfor
+
+	" Because tabbars and other appearing/disappearing windows change
+	" the window numbers, find where we were manually:
+	let back = filter(range(1, winnr("$")), "getwinvar(v:val, 'bbye_back')")[0]
+	if back | exe back . "wincmd w" | unlet w:bbye_back | endif
+
+	" If it hasn't been already deleted by &bufhidden, end its pains now.
+	" Unless it previously was an unnamed buffer and :enew returned it again.
+	if bufexists(buffer) && buffer != bufnr("%")
+		exe "bwipeout" . a:bang . " " . buffer
+	endif
+endfunction
+
 function! s:str2bufnr(buffer)
 	if empty(a:buffer)
 		return bufnr("%")
@@ -82,3 +131,6 @@ endfunction
 
 command! -bang -complete=buffer -nargs=? Bdelete
 	\ :call s:bdelete(<q-bang>, <q-args>)
+
+command! -bang -complete=buffer -nargs=? Bwipeout
+	\ :call s:bwipeout(<q-bang>, <q-args>)

--- a/plugin/bbye.vim
+++ b/plugin/bbye.vim
@@ -35,7 +35,7 @@ function! s:bdelete(bang, buffer_name)
 		" If found a new buffer for this window, mission accomplished:
 		if bufnr("%") != buffer | continue | endif
 
-		call s:new(a:bang) 
+		call s:new(a:bang)
 	endfor
 
 	" Because tabbars and other appearing/disappearing windows change
@@ -84,7 +84,7 @@ function! s:bwipeout(bang, buffer_name)
 		" If found a new buffer for this window, mission accomplished:
 		if bufnr("%") != buffer | continue | endif
 
-		call s:new(a:bang) 
+		call s:new(a:bang)
 	endfor
 
 	" Because tabbars and other appearing/disappearing windows change

--- a/plugin/bbye.vim
+++ b/plugin/bbye.vim
@@ -1,7 +1,7 @@
 if exists("g:loaded_bbye") || &cp | finish | endif
 let g:loaded_bbye = 1
 
-function! s:bdelete(bang, buffer_name)
+function! s:bdelete(bang, buffer_name, action)
 	let buffer = s:str2bufnr(a:buffer_name)
 	let w:bbye_back = 1
 
@@ -46,56 +46,7 @@ function! s:bdelete(bang, buffer_name)
 	" If it hasn't been already deleted by &bufhidden, end its pains now.
 	" Unless it previously was an unnamed buffer and :enew returned it again.
 	if bufexists(buffer) && buffer != bufnr("%")
-		exe "bdelete" . a:bang . " " . buffer
-	endif
-endfunction
-
-function! s:bwipeout(bang, buffer_name)
-	let buffer = s:str2bufnr(a:buffer_name)
-	let w:bbye_back = 1
-
-	if buffer < 0
-		return s:warn("E516: No buffers were deleted. No match for ".a:buffer_name)
-	endif
-
-	if getbufvar(buffer, "&modified") && empty(a:bang)
-		let error = "E89: No write since last change for buffer "
-		return s:warn(error . buffer . " (add ! to override)")
-	endif
-
-	" If the buffer is set to delete and it contains changes, we can't switch
-	" away from it. Hide it before eventual deleting:
-	if getbufvar(buffer, "&modified") && !empty(a:bang)
-		call setbufvar(buffer, "&bufhidden", "hide")
-	endif
-
-	" For cases where adding buffers causes new windows to appear or hiding some
-	" causes windows to disappear and thereby decrement, loop backwards.
-	for window in reverse(range(1, winnr("$")))
-		" For invalid window numbers, winbufnr returns -1.
-		if winbufnr(window) != buffer | continue | endif
-		execute window . "wincmd w"
-
-		" Bprevious also wraps around the buffer list, if necessary:
-		try | exe bufnr("#") > 0 && buflisted(bufnr("#")) ? "buffer #" : "bprevious"
-		catch /^Vim([^)]*):E85:/ " E85: There is no listed buffer
-		endtry
-
-		" If found a new buffer for this window, mission accomplished:
-		if bufnr("%") != buffer | continue | endif
-
-		call s:new(a:bang)
-	endfor
-
-	" Because tabbars and other appearing/disappearing windows change
-	" the window numbers, find where we were manually:
-	let back = filter(range(1, winnr("$")), "getwinvar(v:val, 'bbye_back')")[0]
-	if back | exe back . "wincmd w" | unlet w:bbye_back | endif
-
-	" If it hasn't been already deleted by &bufhidden, end its pains now.
-	" Unless it previously was an unnamed buffer and :enew returned it again.
-	if bufexists(buffer) && buffer != bufnr("%")
-		exe "bwipeout" . a:bang . " " . buffer
+		exe a:action . a:bang . " " . buffer
 	endif
 endfunction
 
@@ -130,7 +81,7 @@ function! s:warn(msg)
 endfunction
 
 command! -bang -complete=buffer -nargs=? Bdelete
-	\ :call s:bdelete(<q-bang>, <q-args>)
+	\ :call s:bdelete(<q-bang>, <q-args>, 'bdelete')
 
 command! -bang -complete=buffer -nargs=? Bwipeout
-	\ :call s:bwipeout(<q-bang>, <q-args>)
+	\ :call s:bdelete(<q-bang>, <q-args>, 'bwipeout')


### PR DESCRIPTION
This is equivalent to :bwipeout, in that it removes all references to that
buffer from the jumplist.

Fixes #2 