### PR TITLE
Skip the quickfix buffer when searching for alternative buffers.

### DIFF
--- a/plugin/bbye.vim
+++ b/plugin/bbye.vim
@@ -36,7 +36,7 @@ function! s:bdelete(action, bang, buffer_name)
 				" If # buffer is listed and not quickfix switch to it
 				buffer #
 				" echom 'swith to alt'
-				break
+				continue
 			endif
 			" Emulate bprevious but excluding quickfix buffers
 			" listed buffer that are not quickfix buffers:
@@ -45,7 +45,7 @@ function! s:bdelete(action, bang, buffer_name)
 			if len(buffers)
 					execute "buffer " . buffers[-1]
 					" echom 'swith to previous'
-					break
+					continue
 			endif
 			let buffers = map(filter(getbufinfo({'buflisted':1}), "getbufvar(v:val.bufnr, '&ft') != 'qf'"), "v:val.bufnr")
 			let buffers = filter(buffers, "v:val > buffer")
@@ -53,13 +53,13 @@ function! s:bdelete(action, bang, buffer_name)
 			if len(buffers)
 					execute "buffer " . buffers[-1]
 					" echom 'swith to last'
-					break
+					continue
 			endif
 		catch /^Vim([^)]*):E85:/ " E85: There is no listed buffer
 		endtry
 
 		" If found a new buffer for this window, mission accomplished:
-		if bufnr("%") != buffer | break | endif
+		if bufnr("%") != buffer | continue | endif
 
 		" Otherwise create an empty buffer
 		call s:new(a:bang)

--- a/plugin/bbye.vim
+++ b/plugin/bbye.vim
@@ -36,7 +36,7 @@ function! s:bdelete(action, bang, buffer_name)
 				" If # buffer is listed and not quickfix switch to it
 				buffer #
 				" echom 'swith to alt'
-				break
+				continue
 			endif
 			" Emulate bprevious but excluding quickfix buffers
 			" listed buffer that are not quickfix buffers:
@@ -45,7 +45,7 @@ function! s:bdelete(action, bang, buffer_name)
 			if len(buffers)
 					execute "buffer " . buffers[-1]
 					" echom 'swith to previous'
-					break
+					continue
 			endif
 			let buffers = map(filter(getbufinfo({'buflisted':1}), "getbufvar(v:val.bufnr, '&ft') != 'qf'"), "v:val.bufnr")
 			let buffers = filter(buffers, "v:val > buffer")
@@ -53,7 +53,7 @@ function! s:bdelete(action, bang, buffer_name)
 			if len(buffers)
 					execute "buffer " . buffers[-1]
 					" echom 'swith to last'
-					break
+					continue
 			endif
 		catch /^Vim([^)]*):E85:/ " E85: There is no listed buffer
 		endtry

--- a/plugin/bbye.vim
+++ b/plugin/bbye.vim
@@ -111,8 +111,39 @@ function! s:error(msg)
 	let v:errmsg = a:msg
 endfunction
 
-command! -bang -complete=buffer -nargs=? Bdelete
-	\ :call s:bdelete("bdelete", <q-bang>, <q-args>)
+function! s:bdeletes(action, bang, range, arg1, arg2, ...)
+	let buffer_list = []
+	if a:range == 1
+		let buffer_list = add(buffer_list, arg1)
+	elseif a:range == 2
+		let buffer_index = a:arg1
+		while buffer_index <= a:arg2
+			let buffer = s:str2bufnr(buffer_index)
+			if buffer >= 0
+				let buffer_list = add(buffer_list, buffer_index)
+			endif
+			let buffer_index = buffer_index + 1
+		endwhile
+	endif
 
-command! -bang -complete=buffer -nargs=? Bwipeout
-	\ :call s:bdelete("bwipeout", <q-bang>, <q-args>)
+	let i = 1
+	for buffer_name in a:000
+		let buffer_list = add(buffer_list, buffer_name)
+		let i = i + 1
+	endfor
+
+	if len(buffer_list) == 0
+		call s:bdelete(a:action, a:bang, "")
+	endif
+
+	for buffer_name in buffer_list
+		call s:bdelete(a:action, a:bang, buffer_name)
+	endfor
+endfunction
+
+command! -bang -complete=buffer -nargs=* -range=% -addr=buffers Bdelete
+	\ :call s:bdeletes("bdelete", <q-bang>, <range>, <line1>, <line2>, <f-args>)
+
+command! -bang -complete=buffer -nargs=* -range=% -addr=buffers Bwipeout
+\ :call s:bdeletes("bwipeout", <q-bang>, <range>, <line1>, <line2>, <f-args>)
+

--- a/plugin/bbye.vim
+++ b/plugin/bbye.vim
@@ -43,17 +43,17 @@ function! s:bdelete(action, bang, buffer_name)
 			let buffers = map(filter(getbufinfo({'buflisted':1}), "getbufvar(v:val.bufnr, '&ft') != 'qf'"), "v:val.bufnr")
 			let buffers = filter(buffers, "v:val < buffer")
 			if len(buffers)
-					execute "buffer " . buffers[-1]
-					" echom 'swith to previous'
-					continue
+				execute "buffer " . buffers[-1]
+				" echom 'swith to previous'
+				continue
 			endif
 			let buffers = map(filter(getbufinfo({'buflisted':1}), "getbufvar(v:val.bufnr, '&ft') != 'qf'"), "v:val.bufnr")
 			let buffers = filter(buffers, "v:val > buffer")
 			" Emulate bprevious but excluding quickfix buffers
 			if len(buffers)
-					execute "buffer " . buffers[-1]
-					" echom 'swith to last'
-					continue
+				execute "buffer " . buffers[-1]
+				" echom 'swith to last'
+				continue
 			endif
 		catch /^Vim([^)]*):E85:/ " E85: There is no listed buffer
 		endtry


### PR DESCRIPTION
Skip the quickfix buffer when searching alternative buffers (like the non listed buffers are already skipped).

When vim-bbye searches for alternative buffer to assign to the window that contains the buffer to be deleted or wipeout it only consider listed buffer.
But among the listed buffer there is the quickfix buffers that are odd candidates.

The pull request makes that these quickfix buffers are not considered as candidates.